### PR TITLE
Add AWS and database config templates

### DIFF
--- a/config/aws-credentials-template.txt
+++ b/config/aws-credentials-template.txt
@@ -1,0 +1,13 @@
+# AWS S3 Configuration Template
+# Copy these lines to your shell profile or export them before running the app
+
+export AWS_ACCESS_KEY_ID="your_access_key_here"
+export AWS_SECRET_ACCESS_KEY="your_secret_key_here"
+export AWS_S3_BUCKET_NAME="your_bucket_name_here"
+export AWS_REGION="your_region_here"
+
+# For your working application, use these values:
+# export AWS_ACCESS_KEY_ID="AKIAWIJIU56NKAUHS7CR"
+# export AWS_SECRET_ACCESS_KEY="YyZcVdlAtRd4FFGnQO/I82NY6axUX+Di4Mfb8gZS"
+# export AWS_S3_BUCKET_NAME="lost-found-campus-sai-ohm-saie-paine"
+# export AWS_REGION="ap-southeast-1" 

--- a/config/database.env.example
+++ b/config/database.env.example
@@ -1,0 +1,19 @@
+# Database Configuration
+DB_HOST=localhost
+DB_NAME=lost_found_campus
+DB_USER=postgres
+DB_PASSWORD=your_password_here
+DB_PORT=5432
+
+# JWT Configuration
+JWT_SECRET_KEY=your_jwt_secret_key_here
+
+# AWS S3 Configuration (optional)
+AWS_ACCESS_KEY_ID=your_aws_access_key
+AWS_SECRET_ACCESS_KEY=your_aws_secret_key
+AWS_REGION=ap-southeast-1
+S3_BUCKET_NAME=lost-found-campus-photos
+
+# Application Configuration
+APP_DEBUG=True
+APP_PORT=8000 


### PR DESCRIPTION
Added aws-credentials-template.txt and database.env.example to provide environment variable templates for AWS S3 and database configuration. These files help developers set up local environments and clarify required settings.