### PR TITLE
Add getImageUrlWithCacheBust for cache-busting images

### DIFF
--- a/frontend/src/util/image.ts
+++ b/frontend/src/util/image.ts
@@ -17,4 +17,26 @@ export const getImageUrl = (imageUrl: string | null | undefined): string => {
 
   // For any other case, assume it's a relative path and prefix with API base URL
   return `${API_BASE_URL}/uploads/${imageUrl}`;
-}; 
+};
+
+// Enhanced version with cache-busting for newly uploaded images
+export const getImageUrlWithCacheBust = (imageUrl: string | null | undefined, itemCreatedAt?: string): string => {
+  const baseUrl = getImageUrl(imageUrl);
+  
+  if (baseUrl === '/placeholder.png') {
+    return baseUrl;
+  }
+  
+  // Add cache-busting parameter for images from items created in the last 5 minutes
+  if (itemCreatedAt) {
+    const createdDate = new Date(itemCreatedAt);
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+    
+    if (createdDate > fiveMinutesAgo) {
+      const separator = baseUrl.includes('?') ? '&' : '?';
+      return `${baseUrl}${separator}t=${Date.now()}`;
+    }
+  }
+  
+  return baseUrl;
+};


### PR DESCRIPTION
Introduces getImageUrlWithCacheBust, which appends a cache-busting query parameter to image URLs for items created within the last 5 minutes. This helps ensure that newly uploaded images are not cached and are displayed immediately.